### PR TITLE
Istio-compatible Spark executor entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ image with additional setup of:
 * [jupyterlab-git](https://github.com/jupyterlab/jupyterlab-git) extension
 * local [MLflow](https://mlflow.org/) server for experiment tracking
 * additional conda environment with python 3.8 and [kedro](https://kedro.readthedocs.io/en/stable/) framework
+* Istio-compatible Spark executor entrypoint
 
 ![jupyterlab-mlops-launcher](docs/jupyterlab-mlops-launcher.png)
 

--- a/jupyterlab-mlops/Dockerfile
+++ b/jupyterlab-mlops/Dockerfile
@@ -30,8 +30,9 @@ RUN mamba create --quiet --yes -p "${CONDA_DIR}/envs/python38" python=3.8 ipytho
     fix-permissions "/home/${NB_USER}"
     
 COPY jupyter_server_config.py jupyter_notebook_config.py /etc/jupyter/
+COPY spark-executor-entrypoint.bash /usr/local/bin/executor
 
-ENV PATH "${CONDA_DIR}/envs/python38/bin:${PATH}"
+ENV PATH "${PATH}:${CONDA_DIR}/envs/python38/bin"
 ENV CONDA_DEFAULT_ENV python38
 ENV MLFLOW_TRACKING_URI=http://localhost:5000
 ENV JUPYTER_ENABLE_LAB=yes

--- a/jupyterlab-mlops/spark-executor-entrypoint.bash
+++ b/jupyterlab-mlops/spark-executor-entrypoint.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+DRIVER=`echo $SPARK_DRIVER_URL | cut -d@ -f 2`
+echo "Checking Spark driver connectivity: $DRIVER"
+SOCKET=/dev/tcp/`echo $DRIVER | tr : /`
+
+while ! timeout 1 bash -c "echo > $SOCKET"; do
+  echo "Driver not reachable, retrying in 1 second..."
+  sleep 1
+done
+
+echo "Running Spark executor"
+exec /usr/local/spark-3.1.2-bin-hadoop3.2/kubernetes/dockerfiles/spark/entrypoint.sh executor


### PR DESCRIPTION
In order to run spark sessions from Kubeflow Notebooks we need to wait for istio-proxy to start before trying to connect to driver process