### PR TITLE
Fixed Executors/Stages tabs in Spark UI

### DIFF
--- a/jupyterlab-mlops/Dockerfile
+++ b/jupyterlab-mlops/Dockerfile
@@ -1,9 +1,24 @@
 FROM jupyter/pyspark-notebook:lab-3.1.9
 
-ARG MLFLOW_VERSION="1.20.2"
+ARG MLFLOW_VERSION="1.21.0"
 ARG KEDRO_VERSION="0.17.5"
 
 USER root
+
+# patch spark UI (https://github.com/jupyterhub/jupyter-server-proxy/issues/57)
+COPY patches/ /tmp/patches
+
+RUN apt update && \
+    apt install -y zip patch && \
+    mkdir -p /tmp/patches/org/apache/spark/ui/static/ && \
+    unzip -p /usr/local/spark/jars/spark-core_2.12-3.1.2.jar org/apache/spark/ui/static/stagepage.js > /tmp/patches/org/apache/spark/ui/static/stagepage.js && \
+    unzip -p /usr/local/spark/jars/spark-core_2.12-3.1.2.jar org/apache/spark/ui/static/utils.js > /tmp/patches/org/apache/spark/ui/static/utils.js && \
+    patch /tmp/patches/org/apache/spark/ui/static/stagepage.js < /tmp/patches/stagepage.js.patch && \
+    patch /tmp/patches/org/apache/spark/ui/static/utils.js < /tmp/patches/utils.js.patch && \
+    pushd /tmp/patches && \
+    zip -u /usr/local/spark/jars/spark-core_2.12-3.1.2.jar org/apache/spark/ui/static/* && \
+    popd && \
+    rm -rf /tmp/patches
 
 # allow passwordless sudo and add group required by kubeflow
 RUN echo "jovyan ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \

--- a/jupyterlab-mlops/Dockerfile
+++ b/jupyterlab-mlops/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update && \
     pushd /tmp/patches && \
     zip -u /usr/local/spark/jars/spark-core_2.12-3.1.2.jar org/apache/spark/ui/static/* && \
     popd && \
-    rm -rf /tmp/patches
+    rm -rf /tmp/patches /var/lib/apt/lists/*
 
 # allow passwordless sudo and add group required by kubeflow
 RUN echo "jovyan ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook && \
@@ -35,7 +35,7 @@ RUN pip install --no-cache-dir jupyterlab-git
 
 # add kfp and install mlflow inside jupyterlab
 RUN mamba install --quiet --yes kfp jupyter-server-proxy -c conda-forge && \
-    pip install mlflow==$MLFLOW_VERSION && \
+    pip --no-cache-dir install mlflow==$MLFLOW_VERSION && \
     mamba clean --all -f -y 
 
 # configure python 3.8 env with kedro

--- a/jupyterlab-mlops/Dockerfile
+++ b/jupyterlab-mlops/Dockerfile
@@ -34,7 +34,8 @@ USER jovyan
 RUN pip install --no-cache-dir jupyterlab-git
 
 # add kfp and install mlflow inside jupyterlab
-RUN mamba install --quiet --yes kfp mlflow=$MLFLOW_VERSION jupyter-server-proxy -c conda-forge && \
+RUN mamba install --quiet --yes kfp jupyter-server-proxy -c conda-forge && \
+    pip install mlflow==$MLFLOW_VERSION && \
     mamba clean --all -f -y 
 
 # configure python 3.8 env with kedro

--- a/jupyterlab-mlops/patches/stagepage.js.patch
+++ b/jupyterlab-mlops/patches/stagepage.js.patch
@@ -1,0 +1,2 @@
+72a73
+>     if (window.location.pathname.startsWith('/notebook')) { indexOfProxy = 0; }

--- a/jupyterlab-mlops/patches/utils.js.patch
+++ b/jupyterlab-mlops/patches/utils.js.patch
@@ -1,0 +1,6 @@
+94a95
+>   if (window.location.pathname.startsWith('/notebook')) { ind = 0; }
+145a147
+>   if (window.location.pathname.startsWith('/notebook')) { ind = 0; }
+179a182
+>     if (window.location.pathname.startsWith('/notebook')) { ind = 0; }


### PR DESCRIPTION
Spark UI has a custom code to handle JS-capable tabs in SparkUI that doesn't like text "proxy" in the URL (see https://github.com/jupyterhub/jupyter-server-proxy/issues/57).

This PR injects one of the suggested solutions for this issue: https://github.com/jupyterhub/jupyter-server-proxy/issues/57#issuecomment-759388944, patching JS files in place